### PR TITLE
Add new triplets for loongarch64

### DIFF
--- a/configure
+++ b/configure
@@ -5993,6 +5993,8 @@ cat >> conftest.c <<EOF
         hppa-linux-gnu
 # elif defined(__ia64__)
         ia64-linux-gnu
+# elif defined(__loongarch64)
+        loongarch64-linux-gnu
 # elif defined(__m68k__) && !defined(__mcoldfire__)
         m68k-linux-gnu
 # elif defined(__mips_hard_float) && defined(__mips_isa_rev) && (__mips_isa_rev >=6) && defined(_MIPSEL)

--- a/configure.ac
+++ b/configure.ac
@@ -884,6 +884,8 @@ cat >> conftest.c <<EOF
         hppa-linux-gnu
 # elif defined(__ia64__)
         ia64-linux-gnu
+# elif defined(__loongarch64)
+        loongarch64-linux-gnu
 # elif defined(__m68k__) && !defined(__mcoldfire__)
         m68k-linux-gnu
 # elif defined(__mips_hard_float) && defined(__mips_isa_rev) && (__mips_isa_rev >=6) && defined(_MIPSEL)


### PR DESCRIPTION
``` 
# install the Makefile of the shared python build
sed -e 's,gcc-8,gcc,;s,g++-8,g++,'  -e '/^OPT/s,-O3,-O2,' -e 's/-O3/-O2/g' -e 's/-fprofile-use *-fprofile-correction//g' -e 's/-fstack-protector /-fstack-protector-strong /g' -e 's/-specs=[^ ]*//g' -e 's/-fdebug-prefix-map=[^ ]*//g' -e 's,^RUNSHARED *=.*,RUNSHARED=,' -e '/BLDLIBRARY/s/-L\. //' \
	/home/loongson/zhangna/python3.9/python3.9-3.9.2/build-shared/Makefile \
	> debian/tmp/usr/lib/python3.9/config-3.9-loongarch64-linux-gnu/Makefile
/bin/bash: debian/tmp/usr/lib/python3.9/config-3.9-loongarch64-linux-gnu/Makefile: No such file or directory
make: *** [debian/rules:865：stamps/stamp-install] 错误 1
dpkg-buildpackage: error: fakeroot debian/rules binary subprocess returned exit status 2
```

最近在debian上编译python3.9  有个报错，发现configure/configure.ac 中没有loongarch64 platform triplet， 因此加了这个patch。请review @loongarch64/dev-team 
其次，在我刚才创建PR的时候，是要求在https://bugs.python.org/ 先有一个issue